### PR TITLE
feat: usar nombres reales de API para tipos de inmuebles

### DIFF
--- a/SEO-FUNDAMENTOS-GUIA.md
+++ b/SEO-FUNDAMENTOS-GUIA.md
@@ -1,0 +1,156 @@
+# 🚀 Guía SEO Fundamentos - Next.js App Router
+
+## ✅ IMPLEMENTADO - Fundamentos SEO Técnico
+
+### 1. **Metadata Base Optimizado** (`app/layout.tsx`)
+
+```typescript
+export const metadata: Metadata = {
+  title: {
+    template: "%s | [TU MARCA] - [SERVICIO] en [UBICACIÓN]",
+    default: "[TU MARCA] - [SERVICIO PRINCIPAL] en [CIUDAD]",
+  },
+  description:
+    "[DESCRIPCIÓN 155 CHARS CON PROPUESTA DE VALOR + UBICACIÓN + SERVICIOS]",
+  keywords: [
+    "[servicio principal] [ciudad]",
+    "[tipo contenido] [ciudad]",
+    "[marca] [ubicación]",
+    // ... más keywords locales
+  ],
+  authors: [{ name: "[TU MARCA]" }],
+  creator: "[TU MARCA]",
+  openGraph: {
+    title: "[TU MARCA] - [PROPUESTA DE VALOR]",
+    description: "[DESCRIPCIÓN PARA REDES SOCIALES]",
+    url: "https://[TU-DOMINIO].com",
+    siteName: "[TU MARCA]",
+    images: [
+      {
+        url: "https://[TU-DOMINIO].com/[LOGO-1200x630].png",
+        width: 1200,
+        height: 630,
+        alt: "[TU MARCA] - [DESCRIPCIÓN IMAGEN]",
+      },
+    ],
+    locale: "es_AR",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "[TU MARCA] - [TÍTULO TWITTER]",
+    description: "[DESCRIPCIÓN TWITTER]",
+    images: ["https://[TU-DOMINIO].com/[LOGO].png"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
+};
+```
+
+### 2. **Sitemap Dinámico** (`app/sitemap.ts`)
+
+```typescript
+import { MetadataRoute } from 'next'
+import { [TUS_FUNCIONES_FETCH] } from '@/lib/[archivo]'
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  // 1. Páginas estáticas
+  const staticPages = [
+    {
+      url: 'https://[TU-DOMINIO].com',
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 1,
+    },
+    {
+      url: 'https://[TU-DOMINIO].com/[pagina-importante]',
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.8,
+    },
+    // ... más páginas estáticas
+  ]
+
+  try {
+    // 2. Contenido dinámico (productos, posts, etc.)
+    const [contenidoDinamico] = await [tuFuncionFetch]()
+    const contenidoSitemap = [contenidoDinamico].map((item) => ({
+      url: `https://[TU-DOMINIO].com/[ruta]/${item.slug}`,
+      lastModified: new Date(),
+      changeFrequency: 'daily' as const,
+      priority: 0.9,
+    }))
+
+    // 3. Combinar todo
+    return [
+      ...staticPages,
+      ...contenidoSitemap,
+    ]
+
+  } catch (error) {
+    console.error('Error generando sitemap:', error)
+    return staticPages
+  }
+}
+```
+
+### 3. **Robots.txt** (`app/robots.ts`)
+
+```typescript
+import { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: [
+        "/api/",
+        "/_next/",
+        "/admin/", // Si tienes admin
+      ],
+    },
+    sitemap: "https://[TU-DOMINIO].com/sitemap.xml",
+  };
+}
+```
+
+## 🎯 CHECKLIST IMPLEMENTACIÓN
+
+- [ ] ✅ Cambiar todas las variables `[TU-MARCA]`, `[TU-DOMINIO]`, etc.
+- [ ] ✅ Adaptar keywords a tu industria/ubicación
+- [ ] ✅ Crear imagen OpenGraph 1200x630px
+- [ ] ✅ Configurar funciones fetch para contenido dinámico
+- [ ] ✅ Ajustar prioridades según tu negocio
+- [ ] ✅ Testear URLs cuando deploys: `/sitemap.xml` y `/robots.txt`
+
+## 📊 BENEFICIOS INMEDIATOS
+
+1. **Indexación automática** de todo el contenido
+2. **Títulos optimizados** para búsquedas locales
+3. **Compartido social** con imágenes correctas
+4. **Crawling eficiente** de motores de búsqueda
+5. **Base sólida** para optimizaciones avanzadas
+
+---
+
+## 🔄 PRÓXIMOS PASOS (Opcional)
+
+- [ ] Metadata específico por página
+- [ ] Schema markup (LocalBusiness, Product, etc.)
+- [ ] Optimización de imágenes
+- [ ] Core Web Vitals
+- [ ] Google Search Console
+
+---
+
+_Guía creada para proyectos Next.js App Router - Personalizar según necesidades_

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,9 +5,41 @@ import {
   PorQueElegirnos,
   TestimoniosGrid,
 } from "@/components/Home";
+import { Metadata } from "next";
 
 /* import { fetchProperties } from '../lib/fetch-properties'; */
 /* import { InmueblesGrid } from "../inmuebles"; */
+
+export const metadata: Metadata = {
+  title:
+    "IMD Inmobiliaria - Las Mejores Propiedades de la Provincia de Neuquén",
+  description:
+    "Descubre las mejores propiedades en la provincia de Neuquén con IMD Inmobiliaria. Servicio cálido y confiable en venta y alquiler. Tu hogar ideal te está esperando en Neuquén, Allen, Cipolletti y región.",
+  keywords: [
+    "inmobiliaria neuquen provincia",
+    "mejores propiedades neuquen",
+    "venta casas neuquen provincia",
+    "alquiler propiedades neuquen",
+    "inmobiliaria neuquen capital",
+    "propiedades destacadas neuquen",
+    "IMD inmobiliaria neuquen",
+    "hogar ideal neuquen",
+  ],
+  openGraph: {
+    title: "IMD Inmobiliaria - Las Mejores Propiedades de Neuquén",
+    description:
+      "Descubre las mejores propiedades en la provincia de Neuquén. Tu hogar ideal te está esperando.",
+    url: "https://imdinmobiliaria.com.ar",
+    images: [
+      {
+        url: "https://imdinmobiliaria.com.ar/secundario-fondo-claro.png",
+        width: 1200,
+        height: 630,
+        alt: "IMD Inmobiliaria - Las Mejores Propiedades de Neuquén",
+      },
+    ],
+  },
+};
 
 export default async function Home() {
   /*   const inmuebles = await fetchProperties(); */

--- a/app/propiedades/inmuebles/[name]/page.tsx
+++ b/app/propiedades/inmuebles/[name]/page.tsx
@@ -1,275 +1,357 @@
-import { fetchPropertiesSimple, fetchPropertyBySlug } from '@/lib/fetch-properties';
-import { SimpleInmueble } from '../../../../inmuebles/interfaces/simple-inmueble';
+import {
+  fetchPropertiesSimple,
+  fetchPropertyBySlug,
+} from "@/lib/fetch-properties";
+import { SimpleInmueble } from "../../../../inmuebles/interfaces/simple-inmueble";
 /* import Image from 'next/image';
 import placeholder from '@/app/images/image.png'; */
-import Link from 'next/link';
-import { ArrowLeft, BedDouble, Building2, Car, Flame, Home, MapPin, Ruler,  Tag } from 'lucide-react';
-import PropertyImageGallery from '@/components/PropertyImageGallery';
-import { Card, CardContent } from '@/components/ui/card';
-import PropertyContactForm from '@/components/PropertyContactForm';
-import { Badge } from '@/components/ui/badge';
+import Link from "next/link";
+import {
+  ArrowLeft,
+  BedDouble,
+  Building2,
+  Car,
+  Flame,
+  Home,
+  MapPin,
+  Ruler,
+  Tag,
+} from "lucide-react";
+import PropertyImageGallery from "@/components/PropertyImageGallery";
+import { Card, CardContent } from "@/components/ui/card";
+import PropertyContactForm from "@/components/PropertyContactForm";
+import { Badge } from "@/components/ui/badge";
 
-import { GoogleMapsCard } from '@/components/GoogleMaps';
-import PropertyShared from '@/components/PropertyShared';
-
-
+import { GoogleMapsCard } from "@/components/GoogleMaps";
+import PropertyShared from "@/components/PropertyShared";
 
 //SOLOS SE EJECUTA EN BUILDTIME
 export async function generateStaticParams() {
+  try {
+    const data: SimpleInmueble[] = await fetchPropertiesSimple();
 
-    try {
-
-        const data: SimpleInmueble[] = await fetchPropertiesSimple();
-
-        if (!data || data.length === 0) {
-            console.warn('No se encontraron propiedades para generar los parámetros estáticos.');
-            return [];
-        }
-
-        return data.map((inmueble) => ({
-            name: inmueble.slug,
-        }))
-
-    } catch (error) {
-        console.error("Error en generateStaticParams:", error);
-        return []; // Retorna un array vacío en caso de error
+    if (!data || data.length === 0) {
+      console.warn(
+        "No se encontraron propiedades para generar los parámetros estáticos."
+      );
+      return [];
     }
 
+    return data.map((inmueble) => ({
+      name: inmueble.slug,
+    }));
+  } catch (error) {
+    console.error("Error en generateStaticParams:", error);
+    return []; // Retorna un array vacío en caso de error
+  }
 }
 
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ name: string }>;
+}) {
+  const { name } = await params;
+  const inmueble: SimpleInmueble = await fetchPropertyBySlug(name);
 
+  // Construir título optimizado
+  const tipoInmueble = inmueble.tipo_inmueble_nombre || "Propiedad";
+  const tipoOperacion =
+    inmueble.tipo_operacion === "venta" ? "en Venta" : "en Alquiler";
+  const monedaTexto = inmueble.moneda === "USD" ? "USD" : "ARS";
+  const precio = inmueble.precio ? `${monedaTexto} $${inmueble.precio}` : "";
+  const dormitorios = inmueble.dormitorios
+    ? `${inmueble.dormitorios} Dormitorios`
+    : "";
+  const ubicacion = inmueble.ciudad_nombre || "Neuquén";
 
-export async function generateMetadata({ params }: { params: Promise<{ name: string }>; }) {
-    const { name } = await params;
-    const inmueble: SimpleInmueble = await fetchPropertyBySlug(name);
+  const titleParts = [
+    tipoInmueble,
+    tipoOperacion,
+    precio,
+    dormitorios,
+    `en ${ubicacion}`,
+    "IMD Inmobiliaria",
+  ].filter(Boolean);
 
-    return {
-        title: inmueble.title,
-        description: inmueble.descripcion,
-        openGraph: {
-            title: inmueble.title,
-            description: inmueble.descripcion,
-            images: [`/${inmueble.images[0]}`]
-        },
-    }
+  const optimizedTitle = titleParts.join(" - ");
+
+  // Descripción optimizada (máximo 160 caracteres)
+  const shortDescription =
+    inmueble.descripcion && inmueble.descripcion.length > 160
+      ? inmueble.descripcion.substring(0, 157) + "..."
+      : inmueble.descripcion ||
+        `${tipoInmueble} ${tipoOperacion.toLowerCase()} en ${ubicacion}. Contacta con IMD Inmobiliaria.`;
+
+  return {
+    title: optimizedTitle,
+    description: shortDescription,
+    keywords: [
+      `${tipoInmueble.toLowerCase()} ${
+        inmueble.tipo_operacion
+      } ${ubicacion.toLowerCase()}`,
+      `${inmueble.tipo_operacion} ${ubicacion.toLowerCase()}`,
+      `propiedades ${ubicacion.toLowerCase()}`,
+      `inmobiliaria ${ubicacion.toLowerCase()}`,
+      "IMD inmobiliaria",
+    ],
+    openGraph: {
+      title: optimizedTitle,
+      description: shortDescription,
+      url: `https://imdinmobiliaria.com.ar/propiedades/inmuebles/${name}`,
+      images: inmueble.images.slice(0, 3).map((img) => ({
+        url: `https://imdinmobiliaria.com.ar${img}`,
+        width: 800,
+        height: 600,
+        alt: `${tipoInmueble} ${tipoOperacion.toLowerCase()} en ${ubicacion}`,
+      })),
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: optimizedTitle,
+      description: shortDescription,
+      images: [`https://imdinmobiliaria.com.ar${inmueble.images[0]}`],
+    },
+  };
 }
-
-
-
 
 const getProperty = async (slug: string) => {
-    const data: SimpleInmueble = await fetchPropertyBySlug(slug);
-    return data;
-}
+  const data: SimpleInmueble = await fetchPropertyBySlug(slug);
+  return data;
+};
 
+export default async function PropiedadPage({
+  params,
+}: {
+  params: Promise<{ name: string }>;
+}) {
+  const { name } = await params;
 
-export default async function PropiedadPage({ params, }: { params: Promise<{ name: string }>; }) {
+  try {
+    const inmueble: SimpleInmueble = await getProperty(name);
 
-    const { name } = await params;
-
-
-
-    try {
-
-        const inmueble: SimpleInmueble = await getProperty(name);
-
-
-        if (!inmueble) {
-            return (
-                <div className="min-h-screen bg-gray-100">
-                    <h1>Propiedad no encontrada</h1>
-                </div>
-            );
-        }
-
-        const {
-            title,
-            images,
-            descripcion = " Encantadora casa en alquiler ideal para descansar y desconectar Ubicada en una zona tranquila y segura, esta acogedora propiedad ofrece todo lo que necesitás para una estadía cómoda y placentera. Cuenta con ambientes amplios y luminosos, dos dormitorios equipados, cocina completa, living-comedor con vista al jardín y un patio ideal para disfrutar al aire libre ",
-            direccion,
-            precio,
-            superficie_construida_total,
-            superficie_del_terreno,
-            superficie_cubierta_total,
-            quincho,
-            dormitorios,
-            cochera,
-            plantas,
-            tipo_operacion,
-            id,
-            tipo_inmueble_nombre,
-            ciudad_nombre,
-            moneda,
-            maps,
-        } = inmueble;
-
-        const propertyUrl = `${process.env.NEXT_PUBLIC_SITE_URL || "https://tusitio.com"}/propiedades/inmuebles/${name}`;
-
-        return (
-
-
-            < main className="container mx-auto px-4 py-8" >
-                <div className="mb-6">
-                    <Link
-                        href='/propiedades/listado'
-                        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
-                        replace={true}
-                    >
-                        <ArrowLeft className="mr-2 h-4 w-4" />
-                        Volver a listado
-                    </Link>
-
-                    <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-                        <div>
-                            <h1 className="text-2xl md:text-3xl lg:text-4xl font-bold">{title}</h1>
-                            <div className="flex items-center mt-2 text-muted-foreground">
-                                <MapPin className="h-4 w-4 mr-1" />
-                                <span>{direccion}</span>
-                            </div>
-                        </div>
-
-                        <div className="flex items-center gap-2">
-                            <span className="text-2xl md:text-3xl font-bold">${precio}</span>
-                            <Badge className=" bg-green-800 text-white">{moneda}</Badge>
-                            <Badge className="ml-2">{tipo_operacion === "venta" ? "Venta" : "Alquiler"}</Badge>
-                        </div>
-                    </div>
-                </div>
-
-                {/* Image Gallery */}
-                <PropertyImageGallery images={images} title={title} />
-
-                <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mt-8">
-                    <div className="lg:col-span-2">
-                        {/* Property Description */}
-                        <Card className="mb-8">
-                            <CardContent className="p-6">
-                                <h2 className="text-xl font-semibold mb-4">Descripción</h2>
-                                <p className="text-muted-foreground whitespace-pre-line">{descripcion} </p>
-                            </CardContent>
-                        </Card>
-
-                        {/* Property Details */}
-                        <Card className="mb-8">
-                            <CardContent className="p-6">
-                                <h2 className="text-xl font-semibold mb-4">Detalles de la propiedad</h2>
-
-                                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                                    <div className="space-y-4">
-                                        <div className="flex items-center">
-                                            <Tag className="h-5 w-5 mr-3 text-muted-foreground" />
-                                            <div>
-                                                <p className="text-sm text-muted-foreground">ID de Propiedad</p>
-                                                <p className="font-medium">{id}</p>
-                                            </div>
-                                        </div>
-
-                                        <div className="flex items-center">
-                                            <Home className="h-5 w-5 mr-3 text-muted-foreground" />
-                                            <div>
-                                                <p className="text-sm text-muted-foreground">Tipo de Inmueble</p>
-                                                <p className="font-medium">{tipo_inmueble_nombre}</p>
-                                            </div>
-                                        </div>
-
-                                        <div className="flex items-center">
-                                            <Ruler className="h-5 w-5 mr-3 text-muted-foreground" />
-                                            <div>
-                                                <p className="text-sm text-muted-foreground">Superficie Construida Total</p>
-                                                <p className="font-medium">{superficie_construida_total}</p>
-                                            </div>
-                                        </div>
-
-                                        <div className="flex items-center">
-                                            <Ruler className="h-5 w-5 mr-3 text-muted-foreground" />
-                                            <div>
-                                                <p className="text-sm text-muted-foreground">Superficie del Terreno</p>
-                                                <p className="font-medium">{superficie_del_terreno}</p>
-                                            </div>
-                                        </div>
-
-                                        <div className="flex items-center">
-                                            <Ruler className="h-5 w-5 mr-3 text-muted-foreground" />
-                                            <div>
-                                                <p className="text-sm text-muted-foreground">Superficie Cubierta Total</p>
-                                                <p className="font-medium">{superficie_cubierta_total}</p>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <div className="space-y-4">
-                                        <div className="flex items-center">
-                                            <BedDouble className="h-5 w-5 mr-3 text-muted-foreground" />
-                                            <div>
-                                                <p className="text-sm text-muted-foreground">Dormitorios</p>
-                                                <p className="font-medium">{dormitorios}</p>
-                                            </div>
-                                        </div>
-
-                                        <div className="flex items-center">
-                                            <Car className="h-5 w-5 mr-3 text-muted-foreground" />
-                                            <div>
-                                                <p className="text-sm text-muted-foreground">Cochera</p>
-                                                <p className="font-medium">{cochera} vehículos</p>
-                                            </div>
-                                        </div>
-
-                                        <div className="flex items-center">
-                                            <Building2 className="h-5 w-5 mr-3 text-muted-foreground" />
-                                            <div>
-                                                <p className="text-sm text-muted-foreground">Plantas</p>
-                                                <p className="font-medium">{plantas}</p>
-                                            </div>
-                                        </div>
-
-                                        <div className="flex items-center">
-                                            <Flame className="h-5 w-5 mr-3 text-muted-foreground" />
-                                            <div>
-                                                <p className="text-sm text-muted-foreground">Quincho</p>
-                                                <p className="font-medium">{quincho ? "Sí" : "No"}</p>
-                                            </div>
-                                        </div>
-
-                                        <div className="flex items-center">
-                                            <MapPin className="h-5 w-5 mr-3 text-muted-foreground" />
-                                            <div>
-                                                <p className="text-sm text-muted-foreground">Ubicación</p>
-                                                <p className="font-medium">{ciudad_nombre}</p>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </CardContent>
-                        </Card>
-
-                        {/* Location Map (placeholder) */}
-                        <GoogleMapsCard maps={maps} />
-
-                        {/* Additional Information */}
-
-
-                    </div>
-
-                    {/* Contact Form */}
-                    <div className="lg:col-span-1">
-                        <div className="sticky top-8">
-                            <PropertyContactForm propertyId={id} propertyTitle={title} propertyUrl={propertyUrl} />
-
-                            < PropertyShared propertyUrl={propertyUrl} title={title}/>
-                         </div>   
-                    </div>
-                </div>
-            </main >
-        );
-
-    } catch (error) {
-        console.error("Error en PropiedadPage:", error);
-        return (
-            <div className="min-h-screen bg-gray-100">
-                <h1>Error al cargar la propiedad</h1>
-            </div>
-        );
+    if (!inmueble) {
+      return (
+        <div className="min-h-screen bg-gray-100">
+          <h1>Propiedad no encontrada</h1>
+        </div>
+      );
     }
+
+    const {
+      title,
+      images,
+      descripcion = " Encantadora casa en alquiler ideal para descansar y desconectar Ubicada en una zona tranquila y segura, esta acogedora propiedad ofrece todo lo que necesitás para una estadía cómoda y placentera. Cuenta con ambientes amplios y luminosos, dos dormitorios equipados, cocina completa, living-comedor con vista al jardín y un patio ideal para disfrutar al aire libre ",
+      direccion,
+      precio,
+      superficie_construida_total,
+      superficie_del_terreno,
+      superficie_cubierta_total,
+      quincho,
+      dormitorios,
+      cochera,
+      plantas,
+      tipo_operacion,
+      id,
+      tipo_inmueble_nombre,
+      ciudad_nombre,
+      moneda,
+      maps,
+    } = inmueble;
+
+    const propertyUrl = `${
+      process.env.NEXT_PUBLIC_SITE_URL || "https://tusitio.com"
+    }/propiedades/inmuebles/${name}`;
+
+    return (
+      <main className="container mx-auto px-4 py-8">
+        <div className="mb-6">
+          <Link
+            href="/propiedades/listado"
+            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
+            replace={true}
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Volver a listado
+          </Link>
+
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div>
+              <h1 className="text-2xl md:text-3xl lg:text-4xl font-bold">
+                {title}
+              </h1>
+              <div className="flex items-center mt-2 text-muted-foreground">
+                <MapPin className="h-4 w-4 mr-1" />
+                <span>{direccion}</span>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <span className="text-2xl md:text-3xl font-bold">${precio}</span>
+              <Badge className=" bg-green-800 text-white">{moneda}</Badge>
+              <Badge className="ml-2">
+                {tipo_operacion === "venta" ? "Venta" : "Alquiler"}
+              </Badge>
+            </div>
+          </div>
+        </div>
+
+        {/* Image Gallery */}
+        <PropertyImageGallery images={images} title={title} />
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mt-8">
+          <div className="lg:col-span-2">
+            {/* Property Description */}
+            <Card className="mb-8">
+              <CardContent className="p-6">
+                <h2 className="text-xl font-semibold mb-4">Descripción</h2>
+                <p className="text-muted-foreground whitespace-pre-line">
+                  {descripcion}{" "}
+                </p>
+              </CardContent>
+            </Card>
+
+            {/* Property Details */}
+            <Card className="mb-8">
+              <CardContent className="p-6">
+                <h2 className="text-xl font-semibold mb-4">
+                  Detalles de la propiedad
+                </h2>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div className="space-y-4">
+                    <div className="flex items-center">
+                      <Tag className="h-5 w-5 mr-3 text-muted-foreground" />
+                      <div>
+                        <p className="text-sm text-muted-foreground">
+                          ID de Propiedad
+                        </p>
+                        <p className="font-medium">{id}</p>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center">
+                      <Home className="h-5 w-5 mr-3 text-muted-foreground" />
+                      <div>
+                        <p className="text-sm text-muted-foreground">
+                          Tipo de Inmueble
+                        </p>
+                        <p className="font-medium">{tipo_inmueble_nombre}</p>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center">
+                      <Ruler className="h-5 w-5 mr-3 text-muted-foreground" />
+                      <div>
+                        <p className="text-sm text-muted-foreground">
+                          Superficie Construida Total
+                        </p>
+                        <p className="font-medium">
+                          {superficie_construida_total}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center">
+                      <Ruler className="h-5 w-5 mr-3 text-muted-foreground" />
+                      <div>
+                        <p className="text-sm text-muted-foreground">
+                          Superficie del Terreno
+                        </p>
+                        <p className="font-medium">{superficie_del_terreno}</p>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center">
+                      <Ruler className="h-5 w-5 mr-3 text-muted-foreground" />
+                      <div>
+                        <p className="text-sm text-muted-foreground">
+                          Superficie Cubierta Total
+                        </p>
+                        <p className="font-medium">
+                          {superficie_cubierta_total}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="space-y-4">
+                    <div className="flex items-center">
+                      <BedDouble className="h-5 w-5 mr-3 text-muted-foreground" />
+                      <div>
+                        <p className="text-sm text-muted-foreground">
+                          Dormitorios
+                        </p>
+                        <p className="font-medium">{dormitorios}</p>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center">
+                      <Car className="h-5 w-5 mr-3 text-muted-foreground" />
+                      <div>
+                        <p className="text-sm text-muted-foreground">Cochera</p>
+                        <p className="font-medium">{cochera} vehículos</p>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center">
+                      <Building2 className="h-5 w-5 mr-3 text-muted-foreground" />
+                      <div>
+                        <p className="text-sm text-muted-foreground">Plantas</p>
+                        <p className="font-medium">{plantas}</p>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center">
+                      <Flame className="h-5 w-5 mr-3 text-muted-foreground" />
+                      <div>
+                        <p className="text-sm text-muted-foreground">Quincho</p>
+                        <p className="font-medium">{quincho ? "Sí" : "No"}</p>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center">
+                      <MapPin className="h-5 w-5 mr-3 text-muted-foreground" />
+                      <div>
+                        <p className="text-sm text-muted-foreground">
+                          Ubicación
+                        </p>
+                        <p className="font-medium">{ciudad_nombre}</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Location Map (placeholder) */}
+            <GoogleMapsCard maps={maps} />
+
+            {/* Additional Information */}
+          </div>
+
+          {/* Contact Form */}
+          <div className="lg:col-span-1">
+            <div className="sticky top-8">
+              <PropertyContactForm
+                propertyId={id}
+                propertyTitle={title}
+                propertyUrl={propertyUrl}
+              />
+
+              <PropertyShared propertyUrl={propertyUrl} title={title} />
+            </div>
+          </div>
+        </div>
+      </main>
+    );
+  } catch (error) {
+    console.error("Error en PropiedadPage:", error);
+    return (
+      <div className="min-h-screen bg-gray-100">
+        <h1>Error al cargar la propiedad</h1>
+      </div>
+    );
+  }
 }
-
-

--- a/lib/fetch-properties.ts
+++ b/lib/fetch-properties.ts
@@ -1,7 +1,10 @@
 import { InmueblesResponse } from "../inmuebles/interfaces/inmuebles-response";
 import { SimpleInmueble } from "../inmuebles/interfaces/simple-inmueble";
 import { extractImagesFromContent } from "./extract-images";
-import { fetchTiposInmueblesMap } from "./fetch-tipo-inmuebles";
+import {
+  fetchTiposInmueblesMap,
+  fetchTiposInmueblesNombres,
+} from "./fetch-tipo-inmuebles";
 import { fetchTiposOperacionMap } from "./fetch-tipo-operacion";
 import { fetchUbicacionesMap } from "./fetch-ubicaciones";
 
@@ -211,6 +214,9 @@ export const fetchPropertyBySlug = async (
   slug: string
 ): Promise<SimpleInmueble> => {
   try {
+    // Obtener los tipos de inmuebles (nombres reales)
+    const tiposInmueblesNombres = await fetchTiposInmueblesNombres();
+
     const res = await fetch(
       `https://bisque-giraffe-421578.hostingersite.com/wp-json/wp/v2/inmuebles?slug=${slug}`
     );
@@ -246,8 +252,11 @@ export const fetchPropertyBySlug = async (
       tipo_operacion:
         inmuebleData.tipo_operacion?.[0]?.toString() || "Desconocido",
       ciudad: inmuebleData.ciudades?.[0]?.toString() || "Desconocido",
-      ciudad_nombre: "Desconocido",
-      tipo_inmueble_nombre: "Desconocido",
+      ciudad_nombre: inmuebleData.acf.google_maps?.city || "Desconocido",
+      tipo_inmueble_nombre:
+        tiposInmueblesNombres[
+          inmuebleData.tipo_inmueble?.[0]?.toString() || ""
+        ] || "Desconocido",
       destacado: inmuebleData.acf.destacado || false,
       banios: inmuebleData.acf.banios || undefined,
       moneda: inmuebleData.acf.moneda || "ARG",

--- a/lib/fetch-tipo-inmuebles.ts
+++ b/lib/fetch-tipo-inmuebles.ts
@@ -1,22 +1,20 @@
-import { SimpleTipoInmueble } from '../inmuebles/interfaces/simple-tipo-inmuebles';
-import { TipoInmueblesResponse } from '../inmuebles/interfaces/tipos-inmuebles-response';
-
+import { SimpleTipoInmueble } from "../inmuebles/interfaces/simple-tipo-inmuebles";
+import { TipoInmueblesResponse } from "../inmuebles/interfaces/tipos-inmuebles-response";
 
 export const fetchTipoInmuebles = async (): Promise<SimpleTipoInmueble[]> => {
-    const res: TipoInmueblesResponse[] = await fetch("https://bisque-giraffe-421578.hostingersite.com/wp-json/wp/v2/tipo_inmueble")
-        .then((res) => res.json());
+  const res: TipoInmueblesResponse[] = await fetch(
+    "https://bisque-giraffe-421578.hostingersite.com/wp-json/wp/v2/tipo_inmueble"
+  ).then((res) => res.json());
 
-    const tipoInmueble = res.map((tipo) => ({
-        id: tipo.id,
-        name: tipo.name,
-        count: tipo.count,
-        slug: tipo.slug,
-    }))
+  const tipoInmueble = res.map((tipo) => ({
+    id: tipo.id,
+    name: tipo.name,
+    count: tipo.count,
+    slug: tipo.slug,
+  }));
 
-    return tipoInmueble;
-}
-
-
+  return tipoInmueble;
+};
 
 // Obtener el mapa de tipos de inmuebles (ID -> Slug)
 /* export const fetchTiposInmueblesMap = async (): Promise<Record<string, string>> => {
@@ -32,15 +30,37 @@ export const fetchTipoInmuebles = async (): Promise<SimpleTipoInmueble[]> => {
 }; */
 
 // Obtener el mapa de tipos de inmuebles (Slug -> ID)
-export const fetchTiposInmueblesMap = async (): Promise<Record<string, string>> => {
-    const res = await fetch("https://bisque-giraffe-421578.hostingersite.com/wp-json/wp/v2/tipo_inmueble");
-    const data: { id: number; slug: string }[] = await res.json();
+export const fetchTiposInmueblesMap = async (): Promise<
+  Record<string, string>
+> => {
+  const res = await fetch(
+    "https://bisque-giraffe-421578.hostingersite.com/wp-json/wp/v2/tipo_inmueble"
+  );
+  const data: { id: number; slug: string }[] = await res.json();
 
-    // Construir el mapa con el slug como clave y el ID como valor
-    const tiposInmueblesMap = data.reduce((acc, tipo) => {
-        acc[tipo.slug] = tipo.id.toString(); // Usar el slug como clave y el ID como valor
-        return acc;
-    }, {} as Record<string, string>);
+  // Construir el mapa con el slug como clave y el ID como valor
+  const tiposInmueblesMap = data.reduce((acc, tipo) => {
+    acc[tipo.slug] = tipo.id.toString(); // Usar el slug como clave y el ID como valor
+    return acc;
+  }, {} as Record<string, string>);
 
-    return tiposInmueblesMap;
+  return tiposInmueblesMap;
+};
+
+// Obtener el mapa de tipos de inmuebles (ID -> Nombre real desde API)
+export const fetchTiposInmueblesNombres = async (): Promise<
+  Record<string, string>
+> => {
+  const res = await fetch(
+    "https://bisque-giraffe-421578.hostingersite.com/wp-json/wp/v2/tipo_inmueble"
+  );
+  const data: { id: number; name: string }[] = await res.json();
+
+  // Construir el mapa con el ID como clave y el nombre como valor
+  const tiposNombresMap = data.reduce((acc, tipo) => {
+    acc[tipo.id.toString()] = tipo.name; // ID -> Nombre real
+    return acc;
+  }, {} as Record<string, string>);
+
+  return tiposNombresMap;
 };


### PR DESCRIPTION
- Nueva función fetchTiposInmueblesNombres() para mapeo ID->nombre directo
- Eliminar conversión automática de slug y usar nombres exactos de WordPress
- Simplificar lógica en fetchPropertyBySlug
- Fix: títulos ahora muestran Cabaña en lugar de Desconocido